### PR TITLE
Use latest version of build_pbf_glyphs

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "clean-download": "shx rm -rf download",
     "clean-build": "shx rm -rf dist build",
     "code_format": "prettier --write --list-different .",
-    "fonts:install_glyph_builder": "cargo install build_pbf_glyphs@1.3.0",
+    "fonts:install_glyph_builder": "cargo install build_pbf_glyphs@1.4.1",
     "fonts:build": "node fonts",
     "fonts": "run-s fonts:install_glyph_builder fonts:build"
   },


### PR DESCRIPTION
Without this change `npm run build` failed with the following error:

```
   Compiling build_pbf_glyphs v1.3.0
error[E0433]: failed to resolve: could not find `generate` in `pbf_font_tools`
   --> /Users/hpg/.cargo/registry/src/index.crates.io-6f17d22bba15001f/build_pbf_glyphs-1.3.0/src/main.rs:136:56
    |
136 |                     if let Ok(stack) = pbf_font_tools::generate::glyph_range_for_face(
    |                                                        ^^^^^^^^ could not find `generate` in `pbf_font_tools`

error[E0433]: failed to resolve: could not find `glyphs` in `pbf_font_tools`
   --> /Users/hpg/.cargo/registry/src/index.crates.io-6f17d22bba15001f/build_pbf_glyphs-1.3.0/src/main.rs:133:50
    |
133 |                 let mut glyphs = pbf_font_tools::glyphs::Glyphs::new();
    |                                                  ^^^^^^ could not find `glyphs` in `pbf_font_tools`
    |
help: consider importing this struct
    |
29  + use pbf_font_tools::Glyphs;
    |
help: if you import `Glyphs`, refer to it directly
    |
133 -                 let mut glyphs = pbf_font_tools::glyphs::Glyphs::new();
133 +                 let mut glyphs = Glyphs::new();
    |

For more information about this error, try `rustc --explain E0433`.
error: could not compile `build_pbf_glyphs` (bin "build_pbf_glyphs") due to 2 previous errors
error: failed to compile `build_pbf_glyphs v1.3.0`, intermediate artifacts can be found at `/var/folders/7s/7z4k6nx13t773txpvsnjpq6c0000gp/T/cargo-installYtiHal`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
ERROR: "fonts:install_glyph_builder" exited with 101.
ERROR: "fonts" exited with 1.
```

This is on macOS 14.0, FWTW.