### PR TITLE
Deploy PR previews

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -43,6 +43,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
+          mkdir -p ../pr
           echo $PR_NUMBER > pr/pr_number
           echo $PR_SHA > pr/pr_sha
           echo "Saved PR# ${{ github.event.pull_request.number }}, SHA# ${{ github.event.pull_request.head.sha }} for upload"

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -1,0 +1,53 @@
+name: Build PR Preview
+on:
+  pull_request:
+    branches: [main]
+    types:
+      - opened
+      - reopened
+      - synchronize
+  workflow_dispatch:
+permissions:
+  contents: read
+  pages: write
+  pull-requests: write
+  id-token: write
+  checks: write
+concurrency: preview-${{ github.ref }}
+jobs:
+  build-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+      - name: Checkout PR Branch 🛎️
+        uses: actions/checkout@v4
+        with:
+          path: pr-branch
+      - name: Install and Build PR Branch 🔧
+        # TODO: when we move shieldlib to its own repo, move shieldlib docs CI also
+        run: |
+          npm ci --include=dev
+          npm run build
+          mv dist ..
+        working-directory: pr-branch
+      - name: Upload Build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: fontstack66
+          path: dist/
+      - name: Save PR attributes
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          echo $PR_NUMBER > pr/pr_number
+          echo $PR_SHA > pr/pr_sha
+          echo "Saved PR# ${{ github.event.pull_request.number }}, SHA# ${{ github.event.pull_request.head.sha }} for upload"
+      - name: Upload PR artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr_ci_artifacts
+          path: pr/

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -43,7 +43,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          mkdir -p ../pr
+          mkdir -p pr
           echo $PR_NUMBER > pr/pr_number
           echo $PR_SHA > pr/pr_sha
           echo "Saved PR# ${{ github.event.pull_request.number }}, SHA# ${{ github.event.pull_request.head.sha }} for upload"

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -1,0 +1,117 @@
+name: Deploy PR Preview
+on:
+  workflow_run:
+    workflows: [Build PR Preview]
+    types:
+      - completed
+  workflow_dispatch:
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: "Download PR Number"
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr_ci_artifacts"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/pr_ci_artifacts.zip`, Buffer.from(download.data));
+      - name: "Download Build"
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "fontstack66"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/fontstack66.zip`, Buffer.from(download.data));
+      - name: "Unzip artifacts"
+        run: |
+          unzip pr_ci_artifacts.zip
+          unzip -d dist fontstack66.zip
+      - name: Set PR variable
+        run: |
+          if [ ! -f pr_number ] || [ ! -f pr_sha ]; then
+            echo "Required files pr_number or pr_sha do not exist. Exiting."
+            exit 1
+          fi
+          PR_NUM=$(cat pr_number)
+          PR_SHA=$(cat pr_sha)
+          if [ -z "$PR_NUM" ] || [ -z "$PR_SHA" ]; then
+            echo "PR_NUM or PR_SHA is empty. Exiting."
+            exit 1
+          fi
+          echo "Configuring deployment for PR# $PR_NUM commit $PR_SHA"
+          echo "PR_NUM=$PR_NUM" >> $GITHUB_ENV
+          echo "PR_SHA=$PR_SHA" >> $GITHUB_ENV
+      - name: Deploy via S3
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --follow-symlinks --delete --exclude '.git/*' --exclude '.github/*'
+        env:
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          SOURCE_DIR: "./dist/fonts"
+          DEST_DIR: pr-font/${{ env.PR_NUM }}
+      - name: Wait for PR Preview Upload (Americana Regular 0-255)
+        uses: cygnetdigital/wait_for_response@v2.0.0
+        with:
+          url: "https://preview.ourmap.us/pr-font/${{ env.PR_NUM }}/Americana-Regular/0-255.pbf"
+          responseCode: "200"
+          timeout: 120000
+          interval: 500
+      - name: Generate Preview text
+        run: |
+          echo "## Live PR Preview:
+          * [Font link](https://preview.ourmap.us/pr-font/${{ env.PR_NUM }}/)
+
+          Live previews are automatically removed once the PR is merged.
+
+          " > pr_preview.md
+          [ -f pr_preview-extra.md ] && cat pr_preview-extra.md >> pr_preview.md || echo "No extra PR preview found."
+      - uses: tibdex/github-app-token@v1
+        id: checks_token
+        with:
+          app_id: 396440 #osm-americana checks app
+          private_key: ${{ secrets.CHECKS_WRITER_SECRET }}
+      - name: Print Preview Links to GitHub Checks
+        uses: LouisBrunner/checks-action@v2.0.0
+        if: always()
+        with:
+          sha: ${{ env.PR_SHA }}
+          token: ${{ steps.checks_token.outputs.token }}
+          name: PR Preview
+          details_url: https://preview.ourmap.us/pr-font/${{ env.PR_NUM }}/
+          conclusion: neutral
+          output: |
+            {"summary":"Preview font changes introduced by this PR", "title":"Font base link for use in maplibre"}
+          output_text_description_file: pr_preview.md

--- a/.github/workflows/s3-cleanup.yml
+++ b/.github/workflows/s3-cleanup.yml
@@ -1,0 +1,24 @@
+name: Delete S3 Files on PR Merged
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  delete-s3-files:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up AWS CLI
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Remove files from S3
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          aws s3 rm s3://${{ secrets.AWS_S3_BUCKET }}/pr-font/${PR_NUMBER}/ --recursive


### PR DESCRIPTION
This PR adds deployment of PR previews for the fonts repo, under the folder /pr-fonts/ rather than /pr/ for the main map. It will also remove old PR previews once the branch is merged.  This workflow code is largely copied from the openstreetmap-americana repo.  This will allow us to test out changes to the font stacks.

This works by copying the built fonts into OSM US's S3 bucket used for americanamap.org assets including the main map's PR previews.

I've added the necessary repository secrets for this to work and created access credentials on the AWS side.

Note that due to github's permissions model, the PR preview will not run until the upload workflow is on the main branch. So we won't fully know if this works until the next PR.