### PR TITLE
[WIP] Switch to Noto Sans Korean

### DIFF
--- a/fonts.js
+++ b/fonts.js
@@ -89,10 +89,6 @@ loadGoogleFonts(bundleFontStacks, bundleFontFolder);
 copyFolderContents(bundleFontFolder, ttfFontFolder);
 
 for (const stack in customFontStacks) {
-  // Set to track seen unicode codepoints
-  const seenCodepoints = new Set();
-
-  console.log(`Building ${stack}`);
   let font;
   for (const stackPart in customFontStacks[stack]) {
     let stackPartDef = customFontStacks[stack][stackPart];
@@ -110,27 +106,14 @@ for (const stack in customFontStacks) {
           subsetRange[0],
           subsetRange[1]
         );
-
-        // Filter out glyphs that have already been added
-        const filteredGlyphArray = subsetGlyphArray.filter((codepoint) => {
-          if (seenCodepoints.has(codepoint)) {
-            console.log("DUPE");
-            return false;
-          } else {
-            seenCodepoints.add(codepoint);
-            return true;
-          }
-        });
-
         const fontSegment = Font.create(inputFontBuffer, {
           type: "ttf",
-          subset: filteredGlyphArray, // Use the filtered array
+          subset: subsetGlyphArray,
           hinting: true,
           compound2simple: true,
           inflate: null,
           combinePath: false,
         });
-
         if (font === undefined) {
           font = fontSegment;
           font.data.name = {
@@ -162,8 +145,6 @@ for (const stack in customFontStacks) {
   fs.writeFileSync(ttfFile, outputBuffer);
   console.log(`Built ${ttfFile}`);
 }
-
-console.log(`..done`);
 
 const pbfBuilderFilename = "~/.cargo/bin/build_pbf_glyphs";
 

--- a/fonts.js
+++ b/fonts.js
@@ -89,6 +89,10 @@ loadGoogleFonts(bundleFontStacks, bundleFontFolder);
 copyFolderContents(bundleFontFolder, ttfFontFolder);
 
 for (const stack in customFontStacks) {
+  // Set to track seen unicode codepoints
+  const seenCodepoints = new Set();
+
+  console.log(`Building ${stack}`);
   let font;
   for (const stackPart in customFontStacks[stack]) {
     let stackPartDef = customFontStacks[stack][stackPart];
@@ -106,14 +110,27 @@ for (const stack in customFontStacks) {
           subsetRange[0],
           subsetRange[1]
         );
+
+        // Filter out glyphs that have already been added
+        const filteredGlyphArray = subsetGlyphArray.filter((codepoint) => {
+          if (seenCodepoints.has(codepoint)) {
+            console.log("DUPE");
+            return false;
+          } else {
+            seenCodepoints.add(codepoint);
+            return true;
+          }
+        });
+
         const fontSegment = Font.create(inputFontBuffer, {
           type: "ttf",
-          subset: subsetGlyphArray,
+          subset: filteredGlyphArray, // Use the filtered array
           hinting: true,
           compound2simple: true,
           inflate: null,
           combinePath: false,
         });
+
         if (font === undefined) {
           font = fontSegment;
           font.data.name = {
@@ -145,6 +162,8 @@ for (const stack in customFontStacks) {
   fs.writeFileSync(ttfFile, outputBuffer);
   console.log(`Built ${ttfFile}`);
 }
+
+console.log(`..done`);
 
 const pbfBuilderFilename = "~/.cargo/bin/build_pbf_glyphs";
 

--- a/fonts.json
+++ b/fonts.json
@@ -251,14 +251,10 @@
       },
       {
         "file": "NotoSans-regular",
-        "ranges": ["cyrillic", "greek", "latin"]
+        "ranges": ["cyrillic", "greek", "latin", "space"]
       }
     ],
     "Americana-Bold": [
-      {
-        "file": "NotoSansKr-700",
-        "ranges": ["space", "hangul"]
-      },
       {
         "file": "NotoSansArabic-700",
         "ranges": ["arabic"]
@@ -361,7 +357,7 @@
       },
       {
         "file": "NotoSans-700",
-        "ranges": ["cyrillic", "greek", "latin"]
+        "ranges": ["cyrillic", "greek", "latin", "space"]
       }
     ],
     "Americana-Italic": [
@@ -467,7 +463,7 @@
       },
       {
         "file": "NotoSans-italic",
-        "ranges": ["cyrillic", "greek", "latin"]
+        "ranges": ["cyrillic", "greek", "latin", "space"]
       }
     ],
     "Americana-Bold-Italic": [
@@ -573,7 +569,7 @@
       },
       {
         "file": "NotoSans-700italic",
-        "ranges": ["cyrillic", "greek", "latin"]
+        "ranges": ["cyrillic", "greek", "latin", "space"]
       }
     ]
   }

--- a/fonts.json
+++ b/fonts.json
@@ -14,10 +14,8 @@
     "Noto Sans Gurmukhi": ["regular", "700"],
     "Noto Sans Hebrew": ["regular", "700"],
     "Noto Rashi Hebrew": ["regular", "700"],
-    "M PLUS Rounded 1c": ["regular", "700"],
     "Noto Sans Kannada": ["regular", "700"],
     "Noto Sans Khmer": ["regular", "700"],
-    "Noto Sans KR": ["regular", "700"],
     "Noto Sans Lao": ["regular", "700"],
     "Noto Sans Malayalam": ["regular", "700"],
     "Noto Sans Myanmar": ["regular", "700"],
@@ -196,20 +194,12 @@
         "ranges": ["hebrew"]
       },
       {
-        "file": "MPlusRounded1C-regular",
-        "ranges": ["fullwidth", "hiragana", "kanbun", "katakana"]
-      },
-      {
         "file": "NotoSansKannada-regular",
         "ranges": ["kannada"]
       },
       {
         "file": "NotoSansKhmer-regular",
         "ranges": ["khmer"]
-      },
-      {
-        "file": "NotoSansKr-regular",
-        "ranges": ["space", "hangul"]
       },
       {
         "file": "NotoSansLao-regular",
@@ -268,10 +258,6 @@
       {
         "file": "NotoSansKr-700",
         "ranges": ["space", "hangul"]
-      },
-      {
-        "file": "MPlusRounded1C-700",
-        "ranges": ["fullwidth", "hiragana", "kanbun", "katakana"]
       },
       {
         "file": "NotoSansArabic-700",
@@ -380,14 +366,6 @@
     ],
     "Americana-Italic": [
       {
-        "file": "NotoSansKr-regular",
-        "ranges": ["space", "hangul"]
-      },
-      {
-        "file": "MPlusRounded1C-regular",
-        "ranges": ["fullwidth", "hiragana", "kanbun", "katakana"]
-      },
-      {
         "file": "NotoSansArabic-regular",
         "ranges": ["arabic"]
       },
@@ -493,14 +471,6 @@
       }
     ],
     "Americana-Bold-Italic": [
-      {
-        "file": "NotoSansKr-700",
-        "ranges": ["space", "hangul"]
-      },
-      {
-        "file": "MPlusRounded1C-700",
-        "ranges": ["fullwidth", "hiragana", "kanbun", "katakana"]
-      },
       {
         "file": "NotoSansArabic-700",
         "ranges": ["arabic"]

--- a/fonts.json
+++ b/fonts.json
@@ -1,7 +1,5 @@
 {
   "font-families": {
-    "Gothic A1": ["regular", "700"],
-    "M PLUS Rounded 1c": ["regular", "700"],
     "Noto Sans": ["regular", "700", "italic", "700italic"],
     "Noto Sans Arabic": ["regular", "700"],
     "Noto Naskh Arabic": ["regular", "700"],
@@ -16,8 +14,10 @@
     "Noto Sans Gurmukhi": ["regular", "700"],
     "Noto Sans Hebrew": ["regular", "700"],
     "Noto Rashi Hebrew": ["regular", "700"],
+    "M PLUS Rounded 1c": ["regular", "700"],
     "Noto Sans Kannada": ["regular", "700"],
     "Noto Sans Khmer": ["regular", "700"],
+    "Noto Sans KR": ["regular", "700"],
     "Noto Sans Lao": ["regular", "700"],
     "Noto Sans Malayalam": ["regular", "700"],
     "Noto Sans Myanmar": ["regular", "700"],
@@ -152,14 +152,6 @@
   "custom-font-stacks": {
     "Americana-Regular": [
       {
-        "file": "GothicA1-regular",
-        "ranges": ["space", "hangul"]
-      },
-      {
-        "file": "MPlusRounded1C-regular",
-        "ranges": ["fullwidth", "hiragana", "kanbun", "katakana"]
-      },
-      {
         "file": "NotoSansArabic-regular",
         "ranges": ["arabic"]
       },
@@ -204,12 +196,20 @@
         "ranges": ["hebrew"]
       },
       {
+        "file": "MPlusRounded1C-regular",
+        "ranges": ["fullwidth", "hiragana", "kanbun", "katakana"]
+      },
+      {
         "file": "NotoSansKannada-regular",
         "ranges": ["kannada"]
       },
       {
         "file": "NotoSansKhmer-regular",
         "ranges": ["khmer"]
+      },
+      {
+        "file": "NotoSansKr-regular",
+        "ranges": ["space", "hangul"]
       },
       {
         "file": "NotoSansLao-regular",
@@ -266,7 +266,7 @@
     ],
     "Americana-Bold": [
       {
-        "file": "GothicA1-700",
+        "file": "NotoSansKr-700",
         "ranges": ["space", "hangul"]
       },
       {
@@ -380,7 +380,7 @@
     ],
     "Americana-Italic": [
       {
-        "file": "GothicA1-regular",
+        "file": "NotoSansKr-regular",
         "ranges": ["space", "hangul"]
       },
       {
@@ -494,7 +494,7 @@
     ],
     "Americana-Bold-Italic": [
       {
-        "file": "GothicA1-700",
+        "file": "NotoSansKr-700",
         "ranges": ["space", "hangul"]
       },
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "americana-fonts",
       "version": "0.1.0",
       "devDependencies": {
-        "fonteditor-core": "^2.1.11",
+        "fonteditor-core": "^2.4.1",
         "glob": "^9.2.1",
         "google-font-installer": "^1.2.0",
         "npm-run-all": "^4.1.5",
@@ -305,7 +305,9 @@
       }
     },
     "node_modules/fonteditor-core": {
-      "version": "2.1.11",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/fonteditor-core/-/fonteditor-core-2.4.1.tgz",
+      "integrity": "sha512-nKDDt6kBQGq665tQO5tCRQUClJG/2MAF9YT1eKHl+I4NasdSb6DgXrv/gMjNxjo9NyaVEv9KU9VZxLHMstN1wg==",
       "dev": true,
       "dependencies": {
         "@xmldom/xmldom": "^0.8.3"
@@ -1733,7 +1735,9 @@
       "dev": true
     },
     "fonteditor-core": {
-      "version": "2.1.11",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/fonteditor-core/-/fonteditor-core-2.4.1.tgz",
+      "integrity": "sha512-nKDDt6kBQGq665tQO5tCRQUClJG/2MAF9YT1eKHl+I4NasdSb6DgXrv/gMjNxjo9NyaVEv9KU9VZxLHMstN1wg==",
       "dev": true,
       "requires": {
         "@xmldom/xmldom": "^0.8.3"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "fonteditor-core": "^2.1.11",
+    "fonteditor-core": "^2.4.1",
     "glob": "^9.2.1",
     "google-font-installer": "^1.2.0",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
Fixes #4 

This PR switches the Hangul font to Noto Sans Korean.  I also tried to switch over the Japanese scripts to Noto Sans as well, but it does not work for unexplained reasons. The fonteditor-core library reports a duplicate glyph codepoint whenever I try.

I also upgraded fonteditor-core for good measure.